### PR TITLE
Add basic reporting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,18 @@ PATH
   remote: .
   specs:
     commons-integrity (0.1)
+      activesupport
       json
       require_all
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
@@ -20,12 +26,15 @@ GEM
     coderay (1.1.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
+    concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     equalizer (0.0.11)
     hashdiff (0.3.7)
+    i18n (1.0.1)
+      concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     json (2.1.0)
     method_source (0.9.0)
@@ -55,6 +64,8 @@ GEM
     ruby-progressbar (1.9.0)
     safe_yaml (1.0.4)
     thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     unicode-display_width (1.3.2)
     virtus (1.0.5)
       axiom-types (~> 0.1)

--- a/README.md
+++ b/README.md
@@ -4,15 +4,45 @@
 
 ## Usage
 
+### Installation
+
 Add to the `Gemfile` dependencies for a proto-commons- repository:
 
     gem 'commons-integrity', github => 'everypolitician/commons-integrity'
 
-Then, to check the integrity of data from the command line, you can run:
+### Configuration
 
-    bundle exec ruby bin/check [files]
+Each check you wish to run within your project should be listed in a
+configuration file (by default `.integrity.yml` in the project's root
+directory, though this can also be specified separately.)
 
-## Adding new Checks
+This will usually specify which file(s) to run against, and any options
+specific to that individual check.
+
+For example:
+
+```yaml
+  WikidataIdentifiers:
+    AppliesTo: 'boundaries/**/*.csv'
+    column_name: 'WIKIDATA'
+    column_case: 'fixed'
+```
+
+## Orchestration
+
+Currently you need to create your own script to run this, and choose how
+to display the errors. We plan to make both of these much simpler.
+
+An example `bin/check` could do something like:
+
+```ruby
+  root = Pathname.new(ARGV.first || '.')
+  files = Pathname.glob(root + '**/*')
+  errors = files.map { |file| Commons::Integrity::Report.new(file: file).errors }
+  puts errors
+```
+
+## Creating new Checks
 
 Add new checks in `lib/commons/integrity/check/` such that they look
 like existing checks.

--- a/commons-integrity.gemspec
+++ b/commons-integrity.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables = ['check']
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'activesupport'
   spec.add_dependency 'json'
   spec.add_dependency 'require_all'
 

--- a/lib/commons/integrity/report.rb
+++ b/lib/commons/integrity/report.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/class/subclasses'
+require 'require_all'
+
+require_relative 'config'
+require_rel 'check'
+
+class Commons
+  class Integrity
+    # Collate the errors from all reports applying to a file
+    class Report
+      def initialize(file:, config: nil)
+        @file = Pathname.new(file)
+        @config = config
+      end
+
+      def errors
+        relevant_checks.flat_map { |check| check.new(file).errors }
+      end
+
+      private
+
+      attr_reader :file, :config
+
+      ALL_CHECKS = Commons::Integrity::Check::Base.descendants
+
+      def relevant_checks
+        return [] unless config
+        ALL_CHECKS.select { |check| file.fnmatch config.for(check.moniker).dig('AppliesTo') }
+      end
+    end
+  end
+end

--- a/test/fixtures/config/match-all-csv.yml
+++ b/test/fixtures/config/match-all-csv.yml
@@ -1,0 +1,2 @@
+WikidataIdentifiers:
+  AppliesTo: '**/*.csv'

--- a/test/fixtures/config/match-all-tsv.yml
+++ b/test/fixtures/config/match-all-tsv.yml
@@ -1,0 +1,2 @@
+WikidataIdentifiers:
+  AppliesTo: '**/*.tsv'

--- a/test/reporting.rb
+++ b/test/reporting.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'commons/integrity/config'
+require 'commons/integrity/report'
+
+describe 'Wikidata identifiers' do
+  subject { Commons::Integrity::Report.new(file: datafile, config: config) }
+  let(:datafile) { 'test/fixtures/wikidata_mixed_case.csv' }
+
+  describe 'when no configuration' do
+    let(:config) { nil }
+
+    it 'reports no errors' do
+      subject.errors.size.must_equal 0
+    end
+  end
+
+  describe 'when file does not match configuration regex' do
+    let(:config) { Commons::Integrity::Config.new('test/fixtures/config/match-all-tsv.yml') }
+
+    it 'reports no errors' do
+      subject.errors.size.must_equal 0
+    end
+  end
+
+  describe 'when file matches configuration regex' do
+    let(:config) { Commons::Integrity::Config.new('test/fixtures/config/match-all-csv.yml') }
+
+    it 'reports errors' do
+      subject.errors.size.must_equal 1
+    end
+
+    it 'has an error of the correct type' do
+      subject.errors.first.category.must_equal :wikidata_id_format
+    end
+
+    it 'knows which file the error was in' do
+      subject.errors.first.filename.to_s.must_equal datafile
+    end
+
+    it 'has a useful error message' do
+      subject.errors.first.message.must_equal 'Invalid wikidata ID: q20067765'
+    end
+  end
+end


### PR DESCRIPTION
First step towards orchestrating the running on Checks. This finds all the Checks relevant to a given data file (through an `AppliesTo` configuration setting), and collates the errors from running each of
those checks.

In theory this means that someone _could_ start using this, by cobbling together a script like that in the README, but in practice we really want to move very quickly towards adding something to do that for them, probably through a provided Rake task (#8) and a choice of built-in output formats (#9, #10)