### PR TITLE
Add Travis badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # commons-integrity
 
+[![Build Status](https://travis-ci.org/everypolitician/commons-integrity.svg?branch=master)](https://travis-ci.org/everypolitician/commons-integrity)
+
 ## Usage
 
 Add to the `Gemfile` dependencies for a proto-commons- repository:


### PR DESCRIPTION
This makes it more obvious that CI is set up on this repo, and provides an easy link for people to see and navigate to the build status.