### PR TITLE
Make requiring code from commons-integrity simpler

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ to display the errors. We plan to make both of these much simpler.
 An example `bin/check` could do something like:
 
 ```ruby
+  require 'commons/integrity'
+
   root = Pathname.new(ARGV.first || '.')
   files = Pathname.glob(root + '**/*')
   errors = files.map { |file| Commons::Integrity::Report.new(file: file).errors }

--- a/lib/commons/integrity.rb
+++ b/lib/commons/integrity.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'require_all'
+
+require_rel 'integrity/check'
+require_rel 'integrity/report'
+
+module Commons
+  # This module contains all the library code for checking the
+  # integrity of data.
+  module Integrity
+  end
+end

--- a/lib/commons/integrity/check/base.rb
+++ b/lib/commons/integrity/check/base.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-class Commons
-  class Integrity
+module Commons
+  module Integrity
     class Check
       # All other checks should inherit from here, and override `errors`
       class Base

--- a/lib/commons/integrity/check/wikidata_identifiers.rb
+++ b/lib/commons/integrity/check/wikidata_identifiers.rb
@@ -3,8 +3,8 @@
 require_relative 'base'
 require 'csv'
 
-class Commons
-  class Integrity
+module Commons
+  module Integrity
     class Check
       # Check that any values in a "wikidata" column look like valid IDs
       #

--- a/lib/commons/integrity/config.rb
+++ b/lib/commons/integrity/config.rb
@@ -2,8 +2,8 @@
 
 require 'yaml'
 
-class Commons
-  class Integrity
+module Commons
+  module Integrity
     # This represents the configuration. For now we only have a single
     # config file, but I expect this will become more complex later, and
     # will likely need split into an abstract `Config` combining

--- a/lib/commons/integrity/report.rb
+++ b/lib/commons/integrity/report.rb
@@ -6,8 +6,8 @@ require 'require_all'
 require_relative 'config'
 require_rel 'check'
 
-class Commons
-  class Integrity
+module Commons
+  module Integrity
     # Collate the errors from all reports applying to a file
     class Report
       def initialize(file:, config: nil)


### PR DESCRIPTION
This pull request hopefully makes it slighty easier to require the code in this repository, in that it:

* Avoids a namespace clash between `class Commons` here and `module Commons` in commons-builder
* Creates an obviously-named file to require (`require 'commons/integrity`)
