### PR TITLE
Check that all area-associated positions have detailed role data

### DIFF
--- a/lib/commons/integrity/check/area_positions_known.rb
+++ b/lib/commons/integrity/check/area_positions_known.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+require 'csv'
+require 'json'
+
+module Commons
+  module Integrity
+    class Check
+      # Ensure we have rich position data for positions associated with boundaries
+      #
+      # This check should be applied to a
+      # boundaries/build/position-data.json file. It'll check
+      # that that file has data for every position mentioned in
+      # the index.json file in the same directory.
+      #
+      # == Configuration Options
+      class AreaPositionsKnown < Base
+        # @return [Array<Error>]
+        # Errors will be in the category `:position_id_message`
+        def errors
+          positions_missing_role_data.map do |position|
+            error(
+              position_id_message: "#{position} was found in #{boundaries_index_pathname} but not in #{pathname}"
+            )
+          end
+        end
+
+        private
+
+        def positions_missing_role_data
+          (position_items_from_index - positions_with_role_data).sort
+        end
+
+        def boundaries_index_pathname
+          pathname.dirname.join('index.json')
+        end
+
+        def boundaries_index_data
+          @boundaries_index_data ||= JSON.parse(
+            boundaries_index_pathname.read,
+            symbolize_names: true
+          )
+        end
+
+        def position_items_from_index
+          Set.new(
+            boundaries_index_data.flat_map do |entry|
+              BoundaryIndexEntry.new(entry).associated_positions
+            end
+          )
+        end
+
+        def positions_with_role_data
+          Set.new(
+            JSON.parse(pathname.read, symbolize_names: true).map do |role|
+              role[:role_id]
+            end
+          )
+        end
+      end
+    end
+
+    # This encapsulates a top-level entry in the JSON file which
+    # acts as an index of the boundary data directories
+    class BoundaryIndexEntry
+      def initialize(entry_data)
+        @entry_data = entry_data
+      end
+
+      def associated_positions
+        entry_data[:associations].map { |association| association[:position_item_id] }
+      end
+
+      private
+
+      attr_reader :entry_data
+    end
+  end
+end

--- a/test/area_positions_known_tests.rb
+++ b/test/area_positions_known_tests.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'commons/integrity/check/wikidata_identifiers'
+require 'commons/integrity/config'
+
+describe 'AreaPositionsKnown' do
+  subject { Commons::Integrity::Check::AreaPositionsKnown.new(file, config: config) }
+  let(:config) { nil }
+
+  describe 'all known positions found' do
+    let(:file) { 'test/fixtures/boundaries-good/position-data.json' }
+
+    it 'should find no errors' do
+      subject.errors.must_be_empty
+    end
+  end
+
+  describe 'one position in the index file has no detailed role data' do
+    let(:file) { 'test/fixtures/boundaries-missing-role-data/position-data.json' }
+
+    it 'should find 1 error' do
+      subject.errors.size.must_equal 1
+    end
+
+    it 'should be of the correct type' do
+      subject.errors.first.category.must_equal :position_id_message
+    end
+
+    it 'should have the expected error message' do
+      subject.errors.first.message.must_match(
+        /Q18964326 was found in .*index.json but not in .*position-data.json/
+      )
+    end
+  end
+end

--- a/test/fixtures/boundaries-good/index.json
+++ b/test/fixtures/boundaries-good/index.json
@@ -1,0 +1,28 @@
+[
+  {
+    "directory": "chamber-constituencies",
+    "area_type_wikidata_item_id": "Q53657274",
+    "associations": [
+      {
+        "comment": "member of the Chamber of Deputies of Brazil",
+        "position_item_id": "Q20058725"
+      }
+    ],
+    "name_columns": {
+      "lang:pt": "nome"
+    }
+  },
+  {
+    "directory": "senate-constituencies",
+    "area_type_wikidata_item_id": "Q53657468",
+    "associations": [
+      {
+        "comment": "Member of the Senate of Brazil",
+        "position_item_id": "Q18964326"
+      }
+    ],
+    "name_columns": {
+      "lang:pt": "nome"
+    }
+  }
+]

--- a/test/fixtures/boundaries-good/position-data.json
+++ b/test/fixtures/boundaries-good/position-data.json
@@ -1,0 +1,45 @@
+[
+  {
+    "role_id": "Q18964326",
+    "role_name": {
+      "lang:pt-br": "Senador",
+      "lang:en": "Member of the Senate of Brazil"
+    },
+    "generic_role_id": "Q15686806",
+    "generic_role_name": {
+      "lang:pt-br": "Senador",
+      "lang:pt": "senador",
+      "lang:en": "senator"
+    },
+    "role_level": "Q6256",
+    "role_type": "Q4175034",
+    "organization_id": "Q2119413",
+    "organization_name": {
+      "lang:pt-br": "Senado Federal",
+      "lang:pt": "Senado Federal do Brasil",
+      "lang:en": "Federal Senate of Brazil"
+    }
+  },
+  {
+    "role_id": "Q20058725",
+    "role_name": {
+      "lang:pt-br": "Deputado federal",
+      "lang:pt": "deputado do Brasil",
+      "lang:en": "member of the Chamber of Deputies of Brazil"
+    },
+    "generic_role_id": "Q1055894",
+    "generic_role_name": {
+      "lang:pt-br": "Deputado",
+      "lang:pt": "deputado",
+      "lang:en": "deputy"
+    },
+    "role_level": "Q6256",
+    "role_type": "Q4175034",
+    "organization_id": "Q1834804",
+    "organization_name": {
+      "lang:pt-br": "Câmara dos Deputados",
+      "lang:pt": "Câmara dos Deputados do Brasil",
+      "lang:en": "Chamber of Deputies"
+    }
+  }
+]

--- a/test/fixtures/boundaries-missing-role-data/index.json
+++ b/test/fixtures/boundaries-missing-role-data/index.json
@@ -1,0 +1,28 @@
+[
+  {
+    "directory": "chamber-constituencies",
+    "area_type_wikidata_item_id": "Q53657274",
+    "associations": [
+      {
+        "comment": "member of the Chamber of Deputies of Brazil",
+        "position_item_id": "Q20058725"
+      }
+    ],
+    "name_columns": {
+      "lang:pt": "nome"
+    }
+  },
+  {
+    "directory": "senate-constituencies",
+    "area_type_wikidata_item_id": "Q53657468",
+    "associations": [
+      {
+        "comment": "Member of the Senate of Brazil",
+        "position_item_id": "Q18964326"
+      }
+    ],
+    "name_columns": {
+      "lang:pt": "nome"
+    }
+  }
+]

--- a/test/fixtures/boundaries-missing-role-data/position-data.json
+++ b/test/fixtures/boundaries-missing-role-data/position-data.json
@@ -1,0 +1,24 @@
+[
+  {
+    "role_id": "Q20058725",
+    "role_name": {
+      "lang:pt-br": "Deputado federal",
+      "lang:pt": "deputado do Brasil",
+      "lang:en": "member of the Chamber of Deputies of Brazil"
+    },
+    "generic_role_id": "Q1055894",
+    "generic_role_name": {
+      "lang:pt-br": "Deputado",
+      "lang:pt": "deputado",
+      "lang:en": "deputy"
+    },
+    "role_level": "Q6256",
+    "role_type": "Q4175034",
+    "organization_id": "Q1834804",
+    "organization_name": {
+      "lang:pt-br": "Câmara dos Deputados",
+      "lang:pt": "Câmara dos Deputados do Brasil",
+      "lang:en": "Chamber of Deputies"
+    }
+  }
+]


### PR DESCRIPTION
In the future, in the course of building data for a country, we will try
to find from Wikidata information about each position that's associated
with an area (e.g. the associated chamber, the labels of the position, etc.)

However, we might not be able to find all the information we require, in
which case there will be positions mentioned in
boundaries/build/index.json that are not found in
boundaries/build/position-data.json. The check implemented in this
commit produces an error if that's the case.

Fixes #18

### Notes

The tests for this won't pass yet because:
* It depends on the change from class-to-module in #16 
* It depends on some fix for #17

... so I'm not requesting a review yet.