### PR TITLE
Add a check for unique CSV identifiers

### DIFF
--- a/lib/commons/integrity/check/unique_csv_identifiers.rb
+++ b/lib/commons/integrity/check/unique_csv_identifiers.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+require 'csv'
+
+module Commons
+  module Integrity
+    class Check
+      # Check that any values in the given columns are unique within the file
+      #
+      # == Configuration Options
+      # * column_names: the columns containing the IDs (default: ["wikidata", "ms_fb"])
+      # * column_case: "fixed" if the column_name must be exactly as specified (default: "any")
+      class UniqueCSVIdentifiers < Base
+        # @return [Array<Error>]
+        # Errors will be in the category `:unique_csv_identifiers`
+        def errors
+          return [] unless pathname_regex.match? pathname.to_s
+          duplicate_values.map do |column_name, value|
+            error(unique_csv_identifiers: "Duplicated #{column_name} value: #{value}")
+          end
+        end
+
+        private
+
+        DEFAULT_COLUMN_NAMES = %w[wikidata ms_fb].freeze
+        DEFAULT_COLUMN_CASE = 'any'
+
+        def csv
+          @csv ||= CSV.read(pathname, headers: true)
+        end
+
+        def pathname_regex
+          Regexp.new(my_config.to_h['pathname_regex'] || '.*')
+        end
+
+        def headers
+          csv.headers
+        end
+
+        def column_names
+          (my_config.to_h['column_names'] || DEFAULT_COLUMN_NAMES).map do |column_name|
+            column_name.send(comparison_conversion)
+          end
+        end
+
+        def comparison_type
+          my_config.to_h['column_case'] || DEFAULT_COLUMN_CASE
+        end
+
+        def comparison_conversion
+          return :to_s if comparison_type == 'fixed'
+          :downcase
+        end
+
+        def columns
+          headers.select do |header|
+            column_names.include? header.send(comparison_conversion)
+          end
+        end
+
+        def duplicate_values_for_column(column_name)
+          csv.values_at(column_name).map(&:first).group_by(&:itself).select do |_group, values|
+            values.length > 1
+          end.keys
+        end
+
+        def duplicate_values
+          columns.flat_map do |column_name|
+            [column_name].product duplicate_values_for_column(column_name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/unique_csv_identifiers.rb
+++ b/test/unique_csv_identifiers.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'commons/integrity/check/unique_csv_identifiers'
+require 'commons/integrity/config'
+
+describe 'unique CSV identifiers' do
+  let(:config) { nil }
+  let(:file) { 'test/fixtures/bad_wikidata.csv' }
+  subject { Commons::Integrity::Check::UniqueCSVIdentifiers.new(file, config: config) }
+
+  it 'finds the duplicate' do
+    subject.errors.size.must_equal 1
+  end
+
+  it 'gets the category right' do
+    subject.errors.sample.category.must_equal :unique_csv_identifiers
+  end
+
+  it 'knows what the duplicate is' do
+    subject.errors.sample.message.must_equal 'Duplicated wikidata value: Q20067765'
+  end
+end


### PR DESCRIPTION
Closes #22.

This adds a check that verifies that for the given column names in a CSV file, all the values in each of those columns is unique. By default it checks `MS_FB` and `WIKIDATA` columns.